### PR TITLE
Updated deprecated OTel Resource attributes names and values to match changes from Effect-TS#5104

### DIFF
--- a/packages/sql-pglite/src/PgLiteClient.ts
+++ b/packages/sql-pglite/src/PgLiteClient.ts
@@ -9,7 +9,7 @@ import type { Custom, Fragment, Primitive } from "@effect/sql/Statement"
 import * as Statement from "@effect/sql/Statement"
 import type { Extensions, InitializedExtensions, PGliteOptions } from "@electric-sql/pglite"
 import { PGlite } from "@electric-sql/pglite"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
 import * as Context from "effect/Context"
@@ -192,10 +192,10 @@ export const make = <TExtensions extends Extensions = Extensions>(
         compiler,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_POSTGRESQL],
-          [Otel.SEMATTRS_DB_NAME, options.database ?? options.username ?? "postgres"],
-          ["server.address", "localhost"],
-          ["server.port", 0]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_POSTGRESQL],
+          [OtelSemConv.ATTR_DB_NAMESPACE, opts.database ?? options.username ?? "postgres"],
+          [OtelSemConv.ATTR_SERVER_ADDRESS, opts.host ?? "localhost"],
+          [OtelSemConv.ATTR_SERVER_PORT, opts.port ?? 5432]
         ],
         transformRows
       }),


### PR DESCRIPTION
## PR Description

Many of the OpenTelemetry Resource attributes have undergone the process of deprecation not once, but twice. Most of the constants holding attribute names have been renamed. These are minor changes.

Additionally, there were numerous changes to the attribute keys themselves. These changes can be considered major.

In the @opentelemetry/semantic-conventions package, new attributes having ongoing discussion are going through a process called incubation, until a consensus about their necessity and form is reached. Otel team [recommends](https://github.com/open-telemetry/opentelemetry-js/blob/main/semantic-conventions/README.md?rgh-link-date=2025-06-26T08%3A07%3A14Z#unstable-semconv) devs to copy them directly into their code. Luckily, it's not necessary because all of the new attribute names and values came out of this process (some of them were changed again) and are now considered stable.

```plaintext
deprecated SEMATTRS_DB_SYSTEM ("db.system")
-> incubated(unstable/experimental)+deprecated ATTR_DB_SYSTEM ("db.system")
-> stable ATTR_DB_SYSTEM_NAME ("db.system.name")

deprecated DBSYSTEMVALUES_POSTGRESQL ("postgresql")
-> incubated(unstable/experimental) DB_SYSTEM_VALUE_POSTGRESQL ("postgresql").
   It's not formally deprecated, meaning it doesn't have `@deprecated` JSDoc
   comment in `@opentelemetry/semantic-conventions` package, but effectively
   those are enum values of deprecated resource attribute `ATTR_DB_SYSTEM`
-> stable DB_SYSTEM_NAME_VALUE_POSTGRESQL ("postgresql")

deprecated SEMATTRS_DB_NAME ("db.name")
-> incubated(unstable/experimental)+deprecated ATTR_DB_NAME ("db.name")
-> stable ATTR_DB_NAMESPACE ("db.namespace")

plain string "server.address"
-> stable+uniform ATTR_SERVER_ADDRESS ("server.address")

plain string "server.port"
-> stable+uniform ATTR_SERVER_PORT ("server.port")
```