### PR TITLE
Fixed mistake in variable name (opts -> options) + removed unnecessary attributes

### DIFF
--- a/packages/sql-pglite/src/PgLiteClient.ts
+++ b/packages/sql-pglite/src/PgLiteClient.ts
@@ -193,9 +193,7 @@ export const make = <TExtensions extends Extensions = Extensions>(
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
           [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_POSTGRESQL],
-          [OtelSemConv.ATTR_DB_NAMESPACE, opts.database ?? options.username ?? "postgres"],
-          [OtelSemConv.ATTR_SERVER_ADDRESS, opts.host ?? "localhost"],
-          [OtelSemConv.ATTR_SERVER_PORT, opts.port ?? 5432]
+          [OtelSemConv.ATTR_DB_NAMESPACE, options.database ?? options.username ?? "postgres"],
         ],
         transformRows
       }),


### PR DESCRIPTION
The last time, I made changes to the effect's PG package and then copied them blindly to pglite. And I'm sorry for that. In this commit, I fixed that and returned the `options` variable. Also, I removed the server name and port completely to follow the convention in effect monorepo. Server name and port are not mentioned in sqlite packages family at all, and so they won't be mentioned here, because there's no server and no network communication per se